### PR TITLE
Fix colon operator warning in redundancy_weighting.m

### DIFF
--- a/MATLAB/Utilities/redundancy_weighting.m
+++ b/MATLAB/Utilities/redundancy_weighting.m
@@ -18,7 +18,7 @@ abstheta = abs(theta * geo.DSO(1)/geo.DSD(1));
 
 w = ones([geo.nDetector(2),geo.nDetector(1)]);
 if apply_wang_weights(geo)
-    for ii = 1:geo.nDetector
+    for ii = 1:geo.nDetector(1)
         t = us(ii);
         if(abs(t) <= abstheta)
             w(:,ii) = 0.5*(sin((pi/2)*atan(t/geo.DSO(1))/(atan(abstheta/geo.DSO(1)))) + 1);


### PR DESCRIPTION
### Problem
When using `redundancy_weighting` in MATLAB, the following warning occurs:
`Warning: Colon operands must be real scalars. This warning will become an error in a future release.`

This is due to `geo.nDetector` being a vector used in a colon expression.

### Fix
This PR replaces `geo.nDetector` with `geo.nDetector(1)` in line 21 of `redundancy_weighting.m`, ensuring the colon operator receives a scalar input.

Tested on MATLAB R2024, and the warning is gone.

Let me know if any additional checks are needed.